### PR TITLE
fix show folder error in linux

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,6 @@ pub async fn show_in_folder(path: String) {
 
     #[cfg(target_os = "linux")]
     {
-        use std::fs;
         use std::fs::metadata;
         use std::path::PathBuf;
         if path.contains(",") {
@@ -52,10 +51,10 @@ pub async fn show_in_folder(path: String) {
 // 页面加载
 #[tauri::command]
 pub fn close_splashscreen(window: tauri::Window) {
-  // 关闭启动视图
-  if let Some(splashscreen) = window.get_window("splashscreen") {
-    splashscreen.close().unwrap();
-  }
-  // 展示主视图
-  window.get_window("main").unwrap().show().unwrap();
+    // 关闭启动视图
+    if let Some(splashscreen) = window.get_window("splashscreen") {
+        splashscreen.close().unwrap();
+    }
+    // 展示主视图
+    window.get_window("main").unwrap().show().unwrap();
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -35,7 +35,7 @@ pub async fn show_in_folder(path: String) {
                     "--type=method_call",
                     "/org/freedesktop/FileManager1",
                     "org.freedesktop.FileManager1.ShowItems",
-                    format!("array:string:\"file://{path}\"").as_str(),
+                    format!("array:string:file://{path}").as_str(),
                     "string:\"\"",
                 ])
                 .spawn()

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -2,7 +2,9 @@ use tauri::{AppHandle, CustomMenuItem, Manager, SystemTray, SystemTrayEvent, Sys
 
 // 加载菜单
 pub fn main_menu() -> SystemTray {
-    let tray_menu = SystemTrayMenu::new().add_item(CustomMenuItem::new("quit".to_string(), "退出"));
+    let tray_menu = SystemTrayMenu::new()
+        .add_item(CustomMenuItem::new("show".to_string(), "显示"))
+        .add_item(CustomMenuItem::new("quit".to_string(), "退出"));
 
     SystemTray::new().with_menu(tray_menu)
 }
@@ -20,6 +22,10 @@ pub fn handler(app: &AppHandle, event: SystemTrayEvent) {
             println!("右键点击图标");
         }
         SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
+            "show" => app.windows().values().for_each(|window| {
+                window.show().unwrap();
+                window.set_focus().unwrap();
+            }),
             "quit" => std::process::exit(0),
             _ => {}
         },


### PR DESCRIPTION
[fix: show folder error in linux](https://github.com/Synaptrix/ChatGPT-Desktop/commit/f812209ed7f3ae7136dc3e58ba3ed26e6a0c159c)
经过测试,路径不加双引号才行,但不知道是不是只有`Ubuntu`才是这样.遇到别的情况再看吧.

[feat: add display tray menu item](https://github.com/Synaptrix/ChatGPT-Desktop/commit/ff51db9ffc5eb0cdd85bfb0e6de70ee20c6de1eb)
这是由于在`linux`中托盘图标点击了就会触发菜单的显示,左右键一样.所以在托盘菜单中增加'显示'菜单项.