### PR TITLE
添加 GPT-4 等多个模型

### DIFF
--- a/src/api/openAi.ts
+++ b/src/api/openAi.ts
@@ -40,7 +40,9 @@ export const getOpenAIResultStreamApi = async (messages: MessageData[]) => {
   if (!apiKey) return
 
   const { updateSessionData } = useSessionStore()
-  const { sessionDataList, chatController } = storeToRefs(useSessionStore())
+  const { currentSession, sessionDataList, chatController } = storeToRefs(
+    useSessionStore()
+  )
   const {
     proxy: { bypass, url: proxyURL },
     modalParams: { temperature, max_tokens }
@@ -61,7 +63,7 @@ export const getOpenAIResultStreamApi = async (messages: MessageData[]) => {
   await fetchEventSource(url, {
     method: 'POST',
     body: JSON.stringify({
-      model: OPEN_AI_MODEL,
+      model: currentSession.value?.model || 'gpt-3.5-turbo',
       messages,
       temperature,
       max_tokens,

--- a/src/components/Function/components/AddSession.vue
+++ b/src/components/Function/components/AddSession.vue
@@ -4,6 +4,18 @@ import type { MessageType } from '@/types'
 const sessionStore = useSessionStore()
 const { switchSession } = sessionStore
 const { isThinking, currentSession, imageParams } = storeToRefs(sessionStore)
+const models: string[] = [
+  'gpt-3.5-turbo',
+  'gpt-3.5-turbo-0301',
+  'gpt-4',
+  'gpt-4-0314',
+  'gpt-4-32k',
+  'gpt-4-32k-0314'
+]
+
+const changeModel = async (value: string | any) => {
+  currentSession.value!.model = value
+}
 
 const handleSelect = async (value: MessageType | any) => {
   await switchSession()
@@ -44,6 +56,27 @@ const handleSelect = async (value: MessageType | any) => {
       </div>
     </template>
   </a-popover>
+
+  <a-dropdown
+    v-if="currentSession?.type === 'text'"
+    trigger="hover"
+    @select="changeModel"
+  >
+    <a-button type="text" :disabled="isThinking">
+      <template #icon>
+        <icon-bulb />
+      </template>
+    </a-button>
+    <template #content>
+      <a-doption
+        v-for="(model, index) in models"
+        :key="index"
+        :value="model"
+        :class="currentSession.model === model ? 'text-red' : 'text-default'"
+        >{{ model }}</a-doption
+      >
+    </template>
+  </a-dropdown>
 
   <a-dropdown trigger="hover" @select="handleSelect">
     <a-button type="text" :disabled="isThinking">

--- a/src/components/Session/index.vue
+++ b/src/components/Session/index.vue
@@ -74,9 +74,21 @@ watch([currentSession, sessionDataList], () => {
           class="relative flex w-[calc(100%-8rem)] flex-col gap-2"
           :class="item.is_ask && 'items-end'"
         >
-          <span class="text-xs text-[var(--color-text-2)]" v-if="showTime">
-            {{ getLocalTime(item.time!) }}
-          </span>
+          <div
+            class="flex flex-row gap-4"
+            :class="item.is_ask && 'flex-row-reverse'"
+          >
+            <span class="text-xs text-[var(--color-text-2)]" v-if="showTime">
+              {{ getLocalTime(item.time!) }}
+            </span>
+
+            <span
+              class="text-xs text-[var(--color-text-2)]"
+              v-if="currentSession?.type === 'text'"
+            >
+              {{ item.model! }}
+            </span>
+          </div>
 
           <div
             class="blink-block"

--- a/src/sqls/index.ts
+++ b/src/sqls/index.ts
@@ -91,6 +91,11 @@ export const initSQL = async () => {
     `ALTER TABLE session ADD COLUMN type TEXT DEFAULT 'text';`,
     true
   )
+  // 3. 2023-05-21 在 session_data 表中添加 model 列，记录对话的模型
+  await executeSQL(
+    `ALTER TABLE session_data ADD COLUMN model TEXT DEFAULT 'gpt-3.5-turbo';`,
+    true
+  )
 }
 
 /**

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -60,7 +60,8 @@ export const useSessionStore = defineStore(
         id: nanoid(),
         title: '',
         role_id: defaultRole.id,
-        type: currentSession.value?.type || 'text'
+        type: currentSession.value?.type || 'text',
+        model: currentSession.value?.model || 'gpt-3.5-turbo'
       }
     }
 
@@ -102,7 +103,8 @@ export const useSessionStore = defineStore(
           is_ask: isAsk,
           is_memory: isMemory,
           message: data,
-          message_type: 'text'
+          message_type: 'text',
+          model: currentSession.value.model
         })
       } else if (messageType === 'image') {
         await insertSQL('session_data', {
@@ -143,6 +145,7 @@ export const useSessionStore = defineStore(
       const newPayload = { ...payload }
       delete newPayload.name
       delete newPayload.isEdit
+      delete newPayload.model
 
       await updateSQL('session', {
         ...newPayload,
@@ -182,6 +185,7 @@ export const useSessionStore = defineStore(
       else {
         // !!!添加了新的字段后，旧的session可能不存在type字段，需要处理一下
         if (!session?.type) session.type = 'text'
+        if (!session?.model) session.model = 'gpt-3.5-turbo'
         currentSession.value = session
       }
 

--- a/src/types/sql.d.ts
+++ b/src/types/sql.d.ts
@@ -35,6 +35,7 @@ export interface SessionData {
   message_type: MessageType
   message: MessageData
   time?: string
+  model?: string
 }
 
 export interface SessionPayload {
@@ -45,6 +46,7 @@ export interface SessionPayload {
   name?: string
   type: MessageType
   isEdit?: boolean
+  model?: string
 }
 
 export interface RolePayload {


### PR DESCRIPTION
- 添加 GPT-4 等多个模型；
- 在一个会话中可以切换模型，切换模型后，之前的会话内容也不会丢失；
- 其它界面的相应调整，显示单条问答的模型名称。